### PR TITLE
feat: Avoid new builds on base docker-compose.yml

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,15 +1,9 @@
 version: "3.4"
 
 services:
-  mailserver:
-    image: djfarrelly/maildev
-    ports:
-      - 1080:80
-    networks:
-      - hc-network
   webapp:
     build:
-      context: webapp
+      context: backend
       target: build-and-test
     volumes:
       - ./webapp:/nitro-web
@@ -17,6 +11,8 @@ services:
       - NUXT_BUILD=/tmp/nuxt # avoid file permission issues when `rm -rf .nuxt/`
       - PUBLIC_REGISTRATION=false
     command: yarn run dev
+    volumes:
+      - webapp_node_modules:/nitro-web/node_modules
   backend:
     build:
       context: backend
@@ -30,6 +26,12 @@ services:
       - SMTP_IGNORE_TLS=true
       - "DEBUG=${DEBUG}"
       - PUBLIC_REGISTRATION=false
+    volumes:
+      - backend_node_modules:/nitro-backend/node_modules
+      - uploads:/nitro-backend/public/uploads
+  neo4j:
+    volumes:
+      - neo4j_data:/data
   maintenance:
     image: humanconnection/maintenance:latest
     build:
@@ -39,6 +41,17 @@ services:
       - hc-network
     ports:
       - 3503:80
+  mailserver:
+    image: djfarrelly/maildev
+    ports:
+      - 1080:80
+    networks:
+      - hc-network
 
 networks:
   hc-network:
+volumes:
+  webapp_node_modules:
+  backend_node_modules:
+  neo4j_data:
+  uploads:

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -1,0 +1,20 @@
+version: "3.4"
+
+services:
+  webapp:
+    build:
+      context: webapp
+      target: production
+      args:
+        - "BUILD_COMMIT=${TRAVIS_COMMIT}"
+  backend:
+    build:
+      context: backend
+      target: production
+      args:
+        - "BUILD_COMMIT=${TRAVIS_COMMIT}"
+  neo4j:
+    build:
+      context: neo4j
+      args:
+        - "BUILD_COMMIT=${TRAVIS_COMMIT}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,11 +3,6 @@ version: "3.4"
 services:
   webapp:
     image: humanconnection/nitro-web:latest
-    build:
-      context: webapp
-      target: production
-      args:
-        - "BUILD_COMMIT=${TRAVIS_COMMIT}"
     ports:
       - 3000:3000
       - 3002:3002
@@ -15,28 +10,18 @@ services:
       - hc-network
     depends_on:
       - backend
-    volumes:
-      - webapp_node_modules:/nitro-web/node_modules
     environment:
       - HOST=0.0.0.0
       - GRAPHQL_URI=http://backend:4000
       - MAPBOX_TOKEN="pk.eyJ1IjoiaHVtYW4tY29ubmVjdGlvbiIsImEiOiJjajl0cnBubGoweTVlM3VwZ2lzNTNud3ZtIn0.bZ8KK9l70omjXbEkkbHGsQ"
   backend:
     image: humanconnection/nitro-backend:latest
-    build:
-      context: backend
-      target: production
-      args:
-        - "BUILD_COMMIT=${TRAVIS_COMMIT}"
     networks:
       - hc-network
     depends_on:
       - neo4j
     ports:
       - 4000:4000
-    volumes:
-      - backend_node_modules:/nitro-backend/node_modules
-      - uploads:/nitro-backend/public/uploads
     environment:
       - NEO4J_URI=bolt://neo4j:7687
       - GRAPHQL_URI=http://backend:4000
@@ -47,10 +32,6 @@ services:
       - "DEBUG=${DEBUG}"
   neo4j:
     image: humanconnection/neo4j:latest
-    build:
-      context: neo4j
-      args:
-        - "BUILD_COMMIT=${TRAVIS_COMMIT}"
     networks:
       - hc-network
     environment:
@@ -60,12 +41,5 @@ services:
     ports:
       - 7687:7687
       - 7474:7474
-    volumes:
-      - neo4j_data:/data
 networks:
   hc-network:
-volumes:
-  webapp_node_modules:
-  backend_node_modules:
-  neo4j_data:
-  uploads:


### PR DESCRIPTION
## 🍰 Pullrequest

If you run:

```
docker-compose -f docker-compose.yml up
```
then the docker images should get pulled from the registry instead of running a local build.


If you run:

```
docker-compose -f docker-compose.yml  -f docker-compose.production.yml up
```

this should change the build stage.

If you run:

```
docker-compose up
```
that should run a local build as before.

### Issues
Avoiding unnecessary build times during deployments in production.

